### PR TITLE
Downgrade versions due to compatibility issues

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
 
 android {
     namespace = "com.fake.soundremote"
-    compileSdk = 35
+    compileSdk = 34
     defaultConfig {
         applicationId = "com.fake.soundremote"
         minSdk = 21

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.7.1"
+androidGradlePlugin = "8.5.2"
 kotlin = "2.0.21"
 ksp = "2.0.21-1.0.26"
 
@@ -14,7 +14,7 @@ hilt-navigation-compose = "1.2.0"
 jopus = "0.3.0"
 jupiter = "5.10.3"
 kotlinx-coroutines = "1.9.0"
-ktx = "1.15.0"
+ktx = "1.13.1"
 ktx-test = "1.6.1"
 lifecycle = "2.8.7"
 material = "1.12.0"


### PR DESCRIPTION
- AGP to 8.5.2 because KGP 2.0.20 fully support AGP up to 8.5
- compileSdk to 34 because of AGP 8.5.2
- androidx.core:core-ktx to 1.13.1 because of compileSdk 34